### PR TITLE
macOS M1 Serialport Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,9 +1079,8 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cd7c0f22290ee2c01457009fa6fc1cae4153d5608a924e5dc423babc2c655"
+version = "4.0.2-alpha.0"
+source = "git+https://gitlab.com/spookyvision1/serialport-rs.git?branch=fix-usb-deprecation#7816e2823c3e56a0552b0d4fb2b6275e27430316"
 dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 tokio = { version = "1.12.0", features = ["full"] }
 structopt = "0.3.23"
 anyhow = "1.0.44"
-serialport = "4.0.1"
+serialport = { git = "https://gitlab.com/spookyvision1/serialport-rs.git", branch = "fix-usb-deprecation" }
 bytes = "1.1.0"
 futures = "0.3.17"
 zip = "0.5.13"


### PR DESCRIPTION
This PR uses a serialport-rs contributor branch that properly enumerates the serial ports on m1 macs.